### PR TITLE
Add Fedora support

### DIFF
--- a/.kitchen.circle.yml
+++ b/.kitchen.circle.yml
@@ -1,0 +1,6 @@
+---
+driver:
+  name: docker
+
+platforms:
+  - name: fedora-21

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,7 @@ platforms:
   - name: windows-2012
     driver:
       box: roboticcheese/windows-2012
+  - name: fedora-21
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - cp .kitchen.travis.yml .kitchen.local.yml
 
 script:
-  - chef exec rake && chef exec kitchen test -c 2
+  - chef exec kitchen test -c 2
 
 after_script:
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :test do
   gem 'coveralls'
   gem 'fauxhai'
   gem 'test-kitchen'
-  gem 'kitchen-digitalocean', '>= 0.8.0'
+  gem 'kitchen-docker'
   gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
   gem 'winrm-transport'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 Dropbox Cookbook
 ================
 [![Cookbook Version](https://img.shields.io/cookbook/v/dropbox.svg)][cookbook]
+[![Linux Build Status](https://img.shields.io/circleci/project/RoboticCheese/dropbox-chef.svg)][circle]
 [![OS X Build Status](https://img.shields.io/travis/RoboticCheese/dropbox-chef.svg)][travis]
 [![Windows Build Status](https://img.shields.io/appveyor/ci/RoboticCheese/dropbox-chef.svg)][appveyor]
 [![Code Climate](https://img.shields.io/codeclimate/github/RoboticCheese/dropbox-chef.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/coveralls/RoboticCheese/dropbox-chef.svg)][coveralls]
 
 [cookbook]: https://supermarket.chef.io/cookbooks/dropbox
+[circle]: https://circleci.com/gh/RoboticCheese/vlc-chef
 [travis]: https://travis-ci.org/RoboticCheese/dropbox-chef
 [appveyor]: https://ci.appveyor.com/project/RoboticCheese/dropbox-chef
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/dropbox-chef
@@ -17,13 +19,8 @@ A Chef cookbook for installing the Dropbox application.
 Requirements
 ============
 
-This cookbook currently requires an OS X or Windows node. While Dropbox does
-distribute packages for Linux, they are kept in a different download area with
-a different API than the OS X and Windows packages.
-
-It consumes the [dmg](https://supermarket.chef.io/cookbooks/dmg) and
-[windows](https://supermarket.chef.io/cookbooks/windows) cookbooks to support
-OS X and Windows installs.
+This cookbook consumes the `dmg`, `windows`, and `yum` community cookbooks to
+support OS X, Windows, and Fedora, respectively.
 
 Usage
 =====
@@ -93,6 +90,10 @@ Provides the Mac OS X platform support.
 ***Chef::Provider::Dropbox::Windows***
 
 Provides the Windows platform support.
+
+***Chef::Provider::Dropbox::Fedora***
+
+Provides the Fedora platform support.
 
 Contributing
 ============

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,22 @@
+machine:
+  ruby:
+    version: 2.1.6
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - rvm install 2.0.0-p645
+  override:
+    - bundle install
+    - rvm-exec 2.0.0-p645 bundle install
+  cache_directories:
+    - /home/ubuntu/.rvm/gems
+
+test:
+  pre:
+    - cp .kitchen.circle.yml .kitchen.local.yml
+  override:
+    - bundle exec rake
+    - rvm-exec 2.0.0-p645 bundle exec rake
+    - bundle exec kitchen verify

--- a/libraries/provider_dropbox.rb
+++ b/libraries/provider_dropbox.rb
@@ -23,6 +23,7 @@ require 'chef-config/path_helper'
 require 'net/http'
 require_relative 'provider_dropbox_mac_os_x'
 require_relative 'provider_dropbox_windows'
+require_relative 'provider_dropbox_fedora'
 
 class Chef
   class Provider

--- a/libraries/provider_dropbox_fedora.rb
+++ b/libraries/provider_dropbox_fedora.rb
@@ -1,0 +1,65 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: dropbox
+# Library:: provider_dropbox_fedora
+#
+# Copyright 2014-2015 Jonathan Hartman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require_relative 'provider_dropbox'
+
+class Chef
+  class Provider
+    class Dropbox < Provider::LWRPBase
+      # A Chef provider for Dropbox for Fedora Linux.
+      #
+      # @author Jonathan Hartman <j@p4nt5.com>
+      class Fedora < Dropbox
+        provides :dropbox, platform: 'fedora'
+
+        private
+
+        #
+        # Configure the Dropbox YUM repo and install the package.
+        #
+        # (see Chef::Provider::Dropbox#install!)
+        #
+        def install!
+          return package(new_resource.source) if new_resource.source
+          yum_repository 'dropbox' do
+            baseurl 'https://linux.dropbox.com/fedora/' \
+                    "#{node['platform_version']}/"
+            gpgkey 'http://linux.dropbox.com/fedora/rpm-public-key.asc'
+          end
+          package 'nautilus-dropbox'
+        end
+
+        #
+        # Remove the Dropbox package and YUM repo
+        #
+        # (see Chef::Provider::Dropbox#remove!)
+        #
+        def remove!
+          package 'nautilus-dropbox' do
+            action :remove
+          end
+          yum_repository 'dropbox' do
+            action :remove
+          end
+        end
+      end
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,9 @@ issues_url       'https://github.com/roboticcheese/dropbox-chef/issues'
 
 depends          'dmg', '~> 2.2'
 depends          'windows', '~> 1.36'
+depends          'yum', '~> 3.7'
 
 supports         'mac_os_x'
 supports         'windows'
+supports         'fedora'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/spec/libraries/provider_dropbox_fedora_spec.rb
+++ b/spec/libraries/provider_dropbox_fedora_spec.rb
@@ -1,0 +1,104 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+require_relative '../../libraries/provider_dropbox_fedora'
+
+describe Chef::Provider::Dropbox::Fedora do
+  let(:name) { 'default' }
+  let(:new_resource) { Chef::Resource::Dropbox.new(name, nil) }
+  let(:provider) { described_class.new(new_resource, nil) }
+
+  describe '.provides?' do
+    let(:platform) { nil }
+    let(:node) { ChefSpec::Macros.stub_node('node.example', platform) }
+    let(:res) { described_class.provides?(node, new_resource) }
+
+    context 'Fedora' do
+      let(:platform) { { platform: 'fedora', version: '22' } }
+
+      it 'returns true' do
+        expect(res).to eq(true)
+      end
+    end
+  end
+
+  describe '#install!' do
+    let(:node) do
+      ChefSpec::Macros.stub_node('node.example',
+                                 platform: 'fedora',
+                                 version: '22')
+    end
+    let(:res) { described_class.provides?(node, new_resource) }
+    let(:source) { nil }
+    let(:new_resource) do
+      r = super()
+      r.source(source) unless source.nil?
+      r
+    end
+
+    before(:each) do
+      allow_any_instance_of(described_class).to receive(:node).and_return(node)
+      [:package, :yum_repository].each do |m|
+        allow_any_instance_of(described_class).to receive(m)
+      end
+    end
+
+    context 'no source override' do
+      let(:source) { nil }
+
+      it 'configures the dropbox YUM repo' do
+        p = provider
+        expect(p).to receive(:yum_repository).with('dropbox').and_yield
+        expect(p).to receive(:baseurl)
+          .with('https://linux.dropbox.com/fedora/22/')
+        expect(p).to receive(:gpgkey)
+          .with('http://linux.dropbox.com/fedora/rpm-public-key.asc')
+        p.send(:install!)
+      end
+
+      it 'installs the dropbox package' do
+        p = provider
+        expect(p).to receive(:package).with('nautilus-dropbox')
+        p.send(:install!)
+      end
+    end
+
+    context 'a source override' do
+      let(:source) { 'http://example.com/dropbox.rpm' }
+
+      it 'does not configure the dropbox YUM repo' do
+        p = provider
+        expect(p).not_to receive(:yum_repository)
+        p.send(:install!)
+      end
+
+      it 'installs dropbox from the package source' do
+        p = provider
+        expect(p).to receive(:package).with('http://example.com/dropbox.rpm')
+        p.send(:install!)
+      end
+    end
+  end
+
+  describe '#remove!' do
+    before(:each) do
+      [:package, :yum_repository].each do |m|
+        allow_any_instance_of(described_class).to receive(m)
+      end
+    end
+
+    it 'removes the dropbox package' do
+      p = provider
+      expect(p).to receive(:package).with('nautilus-dropbox').and_yield
+      expect(p).to receive(:action).with(:remove)
+      p.send(:remove!)
+    end
+
+    it 'removes the dropbox repo' do
+      p = provider
+      expect(p).to receive(:yum_repository).with('dropbox').and_yield
+      expect(p).to receive(:action).with(:remove)
+      p.send(:remove!)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/dropbox_test/metadata.rb
+++ b/test/fixtures/cookbooks/dropbox_test/metadata.rb
@@ -13,4 +13,5 @@ depends          'dropbox'
 
 supports         'mac_os_x'
 supports         'windows'
+supports         'fedora'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/test/integration/default/serverspec/localhost/package_spec.rb
+++ b/test/integration/default/serverspec/localhost/package_spec.rb
@@ -14,4 +14,11 @@ describe 'Dropbox package' do
       expect(subject).to be_installed
     end
   end
+
+  describe package('nautilus-dropbox'),
+           if: !%w(darwin windows).include?(os[:family]) do
+    it 'is installed' do
+      expect(subject).to be_installed
+    end
+  end
 end

--- a/test/integration/uninstall/serverspec/localhost/package_spec.rb
+++ b/test/integration/uninstall/serverspec/localhost/package_spec.rb
@@ -14,4 +14,11 @@ describe 'Dropbox package' do
       expect(subject).not_to be_installed
     end
   end
+
+  describe package('nautilus-dropbox'),
+           if: !%w(darwin windows).include?(os[:family]) do
+    it 'is not installed' do
+      expect(subject).not_to be_installed
+    end
+  end
 end


### PR DESCRIPTION
Potentially would support Fedora 22, but for issues with the yum cookbook and dnf.

```
           ---- Begin output of yum clean headers --disablerepo=* --enablerepo=dropbox ----
           STDOUT:
           STDERR: Yum command has been deprecated, redirecting to '/usr/bin/dnf clean headers --disablerepo=* --enablerepo=dropbox'.
           See 'man dnf' and 'man yum2dnf' for more information.
           To transfer transaction metadata from yum to DNF, run:
           'dnf install python-dnf-plugins-extras-migrate && dnf-2 migrate'

           Error: invalid clean argument: u'headers'
        Mini usage:

           clean [packages|metadata|dbcache|plugins|expire-cache|all]
```