### PR TITLE
Add Debian support

### DIFF
--- a/.kitchen.circle.yml
+++ b/.kitchen.circle.yml
@@ -4,4 +4,5 @@ driver:
 
 platforms:
   - name: ubuntu-14.04
+  - name: debian-8.1
   - name: fedora-21

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,7 @@ platforms:
     driver:
       box: roboticcheese/windows-2012
   - name: ubuntu-14.04
+  - name: debian-8.1
   - name: fedora-21
 
 suites:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v?.?.? (????-??-??)
 - Change `package_url` attribute to `source`
 - Add support for Fedora Linux
 - Add support for Ubuntu Linux
+- Add support for Debian Linux
 
 v0.1.0 (2014-12-27)
 -------------------

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requirements
 ============
 
 This cookbook consumes the `dmg`, `windows`, `apt`, and `yum` community
-cookbooks to support OS X, Windows, Ubuntu, and Fedora, respectively.
+cookbooks to support OS X, Windows, Debian/Ubuntu, and Fedora, respectively.
 
 Usage
 =====
@@ -95,9 +95,9 @@ Provides the Windows platform support.
 
 Provides the Fedora platform support.
 
-***Chef::Provider::Dropbox::Ubuntu***
+***Chef::Provider::Dropbox::Debian***
 
-Provides the Ubuntu platform support.
+Provides the Debian and Ubuntu platform support.
 
 Contributing
 ============

--- a/libraries/provider_dropbox.rb
+++ b/libraries/provider_dropbox.rb
@@ -23,8 +23,8 @@ require 'chef-config/path_helper'
 require 'net/http'
 require_relative 'provider_dropbox_mac_os_x'
 require_relative 'provider_dropbox_windows'
+require_relative 'provider_dropbox_debian'
 require_relative 'provider_dropbox_fedora'
-require_relative 'provider_dropbox_ubuntu'
 
 class Chef
   class Provider

--- a/libraries/provider_dropbox_debian.rb
+++ b/libraries/provider_dropbox_debian.rb
@@ -1,7 +1,7 @@
 # Encoding: UTF-8
 #
 # Cookbook Name:: dropbox
-# Library:: provider_dropbox_ubuntu
+# Library:: provider_dropbox_debian
 #
 # Copyright 2014-2015 Jonathan Hartman
 #
@@ -24,13 +24,14 @@ require_relative 'provider_dropbox'
 class Chef
   class Provider
     class Dropbox < Provider::LWRPBase
-      # A Chef provider for Dropbox for Ubuntu Linux.
+      # A Chef provider for Dropbox for Debian and Ubuntu Linux. The only
+      # difference between the two is in the URL for their APT repos.
       #
       # @author Jonathan Hartman <j@p4nt5.com>
-      class Ubuntu < Dropbox
+      class Debian < Dropbox
         include Chef::DSL::IncludeRecipe
 
-        provides :dropbox, platform: 'ubuntu'
+        provides :dropbox, platform_family: 'debian'
 
         private
 
@@ -66,7 +67,7 @@ class Chef
         #
         def repository(action)
           apt_repository 'dropbox' do
-            uri 'http://linux.dropbox.com/ubuntu'
+            uri "http://linux.dropbox.com/#{node['platform']}"
             distribution node['lsb']['codename']
             components %w(main)
             keyserver 'pgp.mit.edu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -19,6 +19,7 @@ depends          'apt', '~> 2.8'
 
 supports         'mac_os_x'
 supports         'windows'
-supports         'fedora'
 supports         'ubuntu'
+supports         'debian'
+supports         'fedora'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/test/fixtures/cookbooks/dropbox_test/metadata.rb
+++ b/test/fixtures/cookbooks/dropbox_test/metadata.rb
@@ -13,6 +13,7 @@ depends          'dropbox'
 
 supports         'mac_os_x'
 supports         'windows'
-supports         'fedora'
 supports         'ubuntu'
+supports         'debian'
+supports         'fedora'
 # rubocop:enable SingleSpaceBeforeFirstArg


### PR DESCRIPTION
The only difference between Ubuntu and Debian is the platform name used
to build the APT repo URI, so they can share one provider.