### PR TITLE
Fix unit tests for Chef 12.5

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ dependencies:
   pre:
     - rvm install 2.0.0-p645
   override:
+    - gem install -V berkshelf
+    - rvm-exec 2.0.0-p645 gem install -V berkshelf
     - bundle install --without=development integration
     - rvm-exec 2.0.0-p645 bundle install --without=development integration
   cache_directories:

--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,8 @@ dependencies:
   pre:
     - rvm install 2.0.0-p645
   override:
-    - bundle install
-    - rvm-exec 2.0.0-p645 bundle install
+    - bundle install --without=development integration
+    - rvm-exec 2.0.0-p645 bundle install --without=development integration
   cache_directories:
     - /home/ubuntu/.rvm/gems
 

--- a/spec/libraries/provider_dropbox_app_debian_spec.rb
+++ b/spec/libraries/provider_dropbox_app_debian_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_dropbox_app_debian'
 
 describe Chef::Provider::DropboxApp::Debian do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::DropboxApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::DropboxApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_dropbox_app_fedora_spec.rb
+++ b/spec/libraries/provider_dropbox_app_fedora_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_dropbox_app_fedora'
 
 describe Chef::Provider::DropboxApp::Fedora do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::DropboxApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::DropboxApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_dropbox_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_dropbox_app_mac_os_x_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_dropbox_app_mac_os_x'
 
 describe Chef::Provider::DropboxApp::MacOsX do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::DropboxApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::DropboxApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the app directory' do

--- a/spec/libraries/provider_dropbox_app_spec.rb
+++ b/spec/libraries/provider_dropbox_app_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_dropbox_app'
 
 describe Chef::Provider::DropboxApp do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::DropboxApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::DropboxApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#whyrun_supported?' do
     it 'returns true' do

--- a/spec/libraries/provider_dropbox_app_windows_spec.rb
+++ b/spec/libraries/provider_dropbox_app_windows_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_dropbox_app_windows'
 
 describe Chef::Provider::DropboxApp::Windows do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::DropboxApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::DropboxApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe 'PATH' do
     it 'returns the app directory' do

--- a/spec/libraries/provider_dropbox_spec.rb
+++ b/spec/libraries/provider_dropbox_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_dropbox'
 
 describe Chef::Provider::Dropbox do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::Dropbox.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::Dropbox.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#whyrun_supported?' do
     it 'returns true' do


### PR DESCRIPTION
`Chef::Provider.initialize` now raises an exception if passed nil as a `run_context`.